### PR TITLE
Updates to match changed headers in some external datasets

### DIFF
--- a/share/tcl/AnnotSV/AnnotSV-ddd.tcl
+++ b/share/tcl/AnnotSV/AnnotSV-ddd.tcl
@@ -97,7 +97,7 @@ proc updateDDDgeneFile {} {
 	    set Ls [::csv::split $L]
 	    set i_gene      [lsearch -regexp $Ls "gene symbol"];          if {$i_gene == -1} {puts "Bad syntax into $DDDfileDownloaded.\ngene symbol field not found - Exit with error"; exit 2}
 	    set i_disease   [lsearch -regexp $Ls "disease name"];         if {$i_disease == -1} {puts "Bad syntax into $DDDfileDownloaded.\ndisease name field not found - Exit with error"; exit 2}
-	    set i_category  [lsearch -regexp $Ls "DDD category"];         if {$i_category == -1} {puts "Bad syntax into $DDDfileDownloaded.\nDDD category field not found - Exit with error"; exit 2}
+	    set i_category  [lsearch -regexp $Ls "confidence category"];         if {$i_category == -1} {puts "Bad syntax into $DDDfileDownloaded.\nDDD category field not found - Exit with error"; exit 2}
 	    set i_allelic   [lsearch -regexp $Ls "allelic requirement"];  if {$i_allelic == -1} {puts "Bad syntax into $DDDfileDownloaded.\nallelic requirement field not found - Exit with error"; exit 2}
 	    set i_mutation  [lsearch -regexp $Ls "mutation consequence"]; if {$i_mutation == -1} {puts "Bad syntax into $DDDfileDownloaded.\nmutation consequence field not found - Exit with error"; exit 2}
 	    set i_pmids     [lsearch -regexp $Ls "pmids"];                if {$i_pmids == -1} {puts "Bad syntax into $DDDfileDownloaded.\npmids field not found - Exit with error"; exit 2}

--- a/share/tcl/AnnotSV/AnnotSV-pathogenicsv.tcl
+++ b/share/tcl/AnnotSV/AnnotSV-pathogenicsv.tcl
@@ -272,7 +272,7 @@ proc checkClinGenHITS_pathogenicFile {genomeBuild} {
 		set Ls [split $L "\t"]		
 		# Header 1 and 2:
 		#################
-		#Gene Symbol    Gene ID cytoBand        Genomic Location        Haploinsufficiency Score        Haploinsufficiency Description  Haploinsufficiency PMID1        Haploinsufficiency PMID2        Haploinsufficiency PMID3 Triplosensitivity Score  Triplosensitivity Description   Triplosensitivity PMID1 Triplosensitivity PMID2 Triplosensitivity PMID3 Date Last Evaluated     Loss phenotype OMIM ID  Triplosensitive phenotype OMIM ID
+		#Gene Symbol    Gene ID cytoBand        Genomic Location        Haploinsufficiency Score        Haploinsufficiency Description  Haploinsufficiency PMID1        Haploinsufficiency PMID2        Haploinsufficiency PMID3 Triplosensitivity Score  Triplosensitivity Description   Triplosensitivity PMID1 Triplosensitivity PMID2 Triplosensitivity PMID3 Date Last Evaluated     Haploinsufficiency Disease ID  Triplosensitivity Disease ID
 		
 		#ISCA ID        ISCA Region Name        cytoBand        Genomic Location        Haploinsufficiency Score        Haploinsufficiency Description  Haploinsufficiency PMID1        Haploinsufficiency PMID2        Haploinsufficiency PMID3  Triplosensitivity Score Triplosensitivity Description   Triplosensitivity PMID1 Triplosensitivity PMID2 Triplosensitivity PMID3 Date Last Evaluated     Loss phenotype OMIM ID  Triplosensitive phenotype OMIM ID
 		
@@ -283,8 +283,8 @@ proc checkClinGenHITS_pathogenicFile {genomeBuild} {
 		    set i_coord [lsearch -exact $Ls "Genomic Location"]; if {$i_coord == -1} {puts "$ClinGenFileDownloaded"; puts "Bad header line syntax. Genomic Location column not found - Exit with error"; exit 2}
 		    set i_hi [lsearch -exact $Ls "Haploinsufficiency Score"]; if {$i_hi == -1} {puts "$ClinGenFileDownloaded"; puts "Bad header line syntax. Haploinsufficiency Score column not found - Exit with error"; exit 2}
 		    set i_ts [lsearch -exact $Ls "Triplosensitivity Score"]; if {$i_ts == -1} {puts "$ClinGenFileDownloaded"; puts "Bad header line syntax. Triplosensitivity Score column not found - Exit with error"; exit 2}
-		    set i_omimloss [lsearch -exact $Ls "Loss phenotype OMIM ID"]; if {$i_omimloss == -1} {puts "$ClinGenFileDownloaded"; puts "Bad header line syntax. Loss phenotype OMIM ID column not found - Exit with error"; exit 2}
-		    set i_omimgain [lsearch -exact $Ls "Triplosensitive phenotype OMIM ID"]; if {$i_omimgain == -1} {puts "$ClinGenFileDownloaded"; puts "Bad header line syntax. Triplosensitive phenotype OMIM ID column not found - Exit with error"; exit 2}
+		    set i_omimloss [lsearch -exact $Ls "Haploinsufficiency Disease ID"]; if {$i_omimloss == -1} {puts "$ClinGenFileDownloaded"; puts "Bad header line syntax. Haploinsufficiency Disease ID column not found - Exit with error"; exit 2}
+		    set i_omimgain [lsearch -exact $Ls "Triplosensitivity Disease ID"]; if {$i_omimgain == -1} {puts "$ClinGenFileDownloaded"; puts "Bad header line syntax. Triplosensitivity Disease ID column not found - Exit with error"; exit 2}
 		    continue
 		}
 		if {[regexp "^#" $L]} {continue}

--- a/share/tcl/AnnotSV/AnnotSV-pathogenicsv.tcl
+++ b/share/tcl/AnnotSV/AnnotSV-pathogenicsv.tcl
@@ -274,7 +274,7 @@ proc checkClinGenHITS_pathogenicFile {genomeBuild} {
 		#################
 		#Gene Symbol    Gene ID cytoBand        Genomic Location        Haploinsufficiency Score        Haploinsufficiency Description  Haploinsufficiency PMID1        Haploinsufficiency PMID2        Haploinsufficiency PMID3 Triplosensitivity Score  Triplosensitivity Description   Triplosensitivity PMID1 Triplosensitivity PMID2 Triplosensitivity PMID3 Date Last Evaluated     Haploinsufficiency Disease ID  Triplosensitivity Disease ID
 		
-		#ISCA ID        ISCA Region Name        cytoBand        Genomic Location        Haploinsufficiency Score        Haploinsufficiency Description  Haploinsufficiency PMID1        Haploinsufficiency PMID2        Haploinsufficiency PMID3  Triplosensitivity Score Triplosensitivity Description   Triplosensitivity PMID1 Triplosensitivity PMID2 Triplosensitivity PMID3 Date Last Evaluated     Loss phenotype OMIM ID  Triplosensitive phenotype OMIM ID
+		#ISCA ID        ISCA Region Name        cytoBand        Genomic Location        Haploinsufficiency Score        Haploinsufficiency Description  Haploinsufficiency PMID1        Haploinsufficiency PMID2        Haploinsufficiency PMID3  Triplosensitivity Score Triplosensitivity Description   Triplosensitivity PMID1 Triplosensitivity PMID2 Triplosensitivity PMID3 Date Last Evaluated     Haploinsufficiency Disease ID  Triplosensitivity Disease ID
 		
 		# Selection of the pathogenic variants to keep:
 		###########################################


### PR DESCRIPTION
File headers have changed in ClinGen and DDD datasets. Fix column names in AnnotSV to be able to update these datasets.

These commits are made as part of my job at SeqOIA (https://laboratoire-seqoia.fr/). I hope this will be useful for other users.