### PR TITLE
Fix: searchForAFreePortNumber

### DIFF
--- a/share/bash/AnnotSV/searchForAFreePortNumber.bash
+++ b/share/bash/AnnotSV/searchForAFreePortNumber.bash
@@ -1,6 +1,3 @@
 #!/bin/bash
-ss -tln |
-  awk 'NR > 1{gsub(/.*:/,"",$4); print $4}' |
-  sort -un |
-  awk -v n=50000 '$0 < n {next}; $0 == n {n++; next}; {exit}; END {print n}'
 
+comm -23 <(seq 5000 50000 | sort) <(ss -Htan | awk '{print $4}' | cut -d':' -f2 | sort -u) | head -n 1


### PR DESCRIPTION
Previous version of this script always answer 5000 even if 5000 port is used.

Warning: This script scan only port between 5_000 to 50_000 so user can't launch more than 45_000 instance of AnnotSV in parallel.