### PR TITLE
Update install-exomiser-2 command in Makefile to support PREFIX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,8 +189,7 @@ install-exomiser-1: 2406_phenotype.zip
 	$(RM) exomiser-rest-prioritiser-14.1.0.jar
 
 install-exomiser-2:
-	install -p -m 0755 $(PROPERTIES) $(DESTDIR)$(ETCDIR)/$(ANNOTSV)
-	$(CPDIR) share/AnnotSV/jar/ $(DESTDIR)$(SHAREDIR)/$(ANNOTSV)/
+	install -D -p -m 0755 $(PROPERTIES) $(DESTDIR)$(ETCDIR)/$(ANNOTSV)
 
 install-exomiser-3:
 	@echo ""


### PR DESCRIPTION
`make PREFIX=. install-exomiser` works fine, but it appears that there are a couple of problems with this command when a PREFIX other than the src directory is used:

* there may not be a $PREFIX/etc directory, so $(PROPERTIES) cannot be installed there (fixed with the `-D` option)
* install-exomiser-1 writes the exomiser ajar to `$(DESTDIR)$(JARDIR)` (which ultimately resolves to `$(DESTDIR)/$(PREFIX)/share$(AnnotSV)/jar`), but install-exomiser-2 is trying to copy from (literal) `share/AnnotSV/jar` (which does end up being where install-exomiser-1 put it if DESTDIR='' and PREFIX='.'), but which is empty if make had been run with different PREFIX). Furthermore, it's not clear to me that this cp command is even needed, since $(DESTDIR)$(SHAREDIR)/$(ANNOTSV)/jar is where that file was already installed in install-exomiser-1.